### PR TITLE
bump rng to 0.9.0; bump petgraph to 0.8.1; pub use rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +45,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
@@ -97,7 +109,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap 1.9.3",
  "textwrap",
@@ -198,13 +210,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
 ]
 
@@ -229,6 +248,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -337,12 +361,14 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.2",
  "indexmap 2.7.1",
+ "serde",
 ]
 
 [[package]]
@@ -389,7 +415,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -411,21 +437,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -433,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
@@ -593,9 +625,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -770,13 +805,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -784,6 +837,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ documentation = "https://docs.rs/petgraph-gen"
 name = "petgraph_gen"
 
 [dependencies]
-petgraph = "0.7"
-rand = "0.8.5"
+petgraph = "0.8.1"
+rand = "0.9.0"
 rustc-hash = "1.1.0"
 
 [dev-dependencies]
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 criterion = "0.4"
 
 [[bench]]

--- a/src/barabasi_albert.rs
+++ b/src/barabasi_albert.rs
@@ -2,8 +2,7 @@ use crate::star_graph;
 use petgraph::graph::{IndexType, NodeIndex};
 use petgraph::prelude::EdgeRef;
 use petgraph::{EdgeType, Graph};
-use rand::distributions::Distribution;
-use rand::distributions::Uniform;
+use rand::distr::{Distribution as _, Uniform};
 use rand::Rng;
 
 /// Generates a random graph with `n` nodes using the [Barabási-Albert][ba] model. The process
@@ -15,7 +14,7 @@ use rand::Rng;
 /// # Examples
 /// ```
 /// use petgraph::Graph;
-/// use petgraph_gen::barabasi_albert_graph;
+/// use petgraph_gen::{barabasi_albert_graph, rand};
 ///
 /// let mut rng = rand::thread_rng();
 /// let graph: Graph<(), ()> = barabasi_albert_graph(&mut rng, 100, 3, None);
@@ -75,7 +74,7 @@ pub fn barabasi_albert_graph<
 
     for _ in initial_node_count..n {
         let node = graph.add_node(());
-        let uniform_distribution = Uniform::new(0, repeated_nodes.len());
+        let uniform_distribution = Uniform::new(0, repeated_nodes.len()).unwrap();
 
         let mut i = 0;
         while i < m {
@@ -107,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_directed_barabasi_albert_graph_nodes_have_at_most_m_outgoing_edges() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let graph: DiGraph<(), ()> = barabasi_albert_graph(&mut rng, 100, 3, None);
         graph.node_indices().for_each(|node| {
             let outgoing_edges = graph.edges_directed(node, petgraph::Outgoing).count();
@@ -117,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_directed_barabasi_albert_graph_with_initial_graph() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let graph: DiGraph<(), ()> = barabasi_albert_graph(&mut rng, 100, 3, complete_graph(4));
         assert_eq!(graph.node_count(), 100);
         assert_eq!(graph.edge_count(), 300);
@@ -129,7 +128,7 @@ mod tests {
 
     #[test]
     fn test_barabasi_albert_graph_with_maximum_sized_initial_graph() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let star_graph: Graph<(), ()> = barabasi_albert_graph(&mut rng, 5, 4, star_graph(4));
         assert_eq!(star_graph.node_count(), 5);
         assert_eq!(star_graph.edge_count(), 4);
@@ -139,35 +138,35 @@ mod tests {
     #[test]
     #[should_panic(expected = "m must be greater than 0")]
     fn test_barabasi_albert_graph_panics_if_m_equals_0() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let _: Graph<(), ()> = barabasi_albert_graph(&mut rng, 5, 0, None);
     }
 
     #[test]
     #[should_panic(expected = "m must be less than n")]
     fn test_barabasi_albert_graph_panics_if_m_is_greater_than_or_equal_to_n() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let _: Graph<(), ()> = barabasi_albert_graph(&mut rng, 5, 5, None);
     }
 
     #[test]
     #[should_panic(expected = "must have at least one edge")]
     fn test_barabasi_albert_graph_panics_if_initial_graph_has_no_edges() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let _: Graph<(), ()> = barabasi_albert_graph(&mut rng, 5, 3, empty_graph(3));
     }
 
     #[test]
     #[should_panic(expected = "must have at least m nodes")]
     fn test_barabasi_albert_graph_panics_if_initial_graph_has_less_than_m_nodes() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let _: Graph<(), ()> = barabasi_albert_graph(&mut rng, 5, 3, complete_graph(2));
     }
 
     #[test]
     #[should_panic(expected = "must have at most n nodes")]
     fn test_barabasi_albert_graph_panics_if_initial_graph_has_more_than_n_nodes() {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let _: Graph<(), ()> = barabasi_albert_graph(&mut rng, 5, 3, complete_graph(6));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod classic;
 mod common;
 mod erdos_renyi;
 
+pub use rand;
 pub use self::barabasi_albert::barabasi_albert_graph;
 pub use self::classic::complete_graph;
 pub use self::classic::empty_graph;


### PR DESCRIPTION
rng 0.9.0 has some API changes
petgraph 0.8.1 seems to have algoritm additions

`pub use rng` will make it easier for consumers to use this crate without adding an extra dep. And it makes it possible for projects who uses different versions of rng in their project to use this crate.
